### PR TITLE
Simplify

### DIFF
--- a/.runpython.yaml
+++ b/.runpython.yaml
@@ -1,0 +1,3 @@
+detail: False
+summary_file: error_summary
+timeout: 700

--- a/error_summary
+++ b/error_summary
@@ -1,0 +1,4 @@
+2019-01-27 11:35:53,485 | root | INFO: test_notebooks/the_good.ipynb:	Success	(kernel: python3)
+2019-01-27 11:35:55,824 | root | INFO: test_notebooks/the_bad.ipynb:	Failure	(kernel: python3)
+2019-01-27 11:35:57,050 | root | INFO: test_notebooks/nested_folder/more_good_stuff.ipynb:	Success	(kernel: python3)
+2019-01-27 11:35:58,279 | root | INFO: test_notebooks/nested_folder/the_ugly.ipynb:	Failure	(kernel: python3)

--- a/run_notebooks/config.py
+++ b/run_notebooks/config.py
@@ -5,7 +5,7 @@ import yaml
 DEFAULT_CONFIG_PATH = Path('~/.run_python/config.yaml').expanduser()
 
 
-def __load_yaml(filename):
+def _load_yaml(filename):
     with open(filename) as yaml_handle:
         yaml_contents = yaml.load(yaml_handle)
     return yaml_contents
@@ -20,10 +20,10 @@ class Config():
         """
         self.__dict__ = {
             'timeout': 600,
-            'log_summary':  True,
-            'log_detail': True,
-            'log_summary_name': '.error_log_summary',
-            'log_detail_name': '.error_log_detail',
+            'summary':  True,
+            'detail': True,
+            'summary_file': '.error_log_summary',
+            'detail_file': '.error_log_detail',
             'kernel_name': None,
         }
 
@@ -56,11 +56,11 @@ class Config():
         filename = Path(filename).expanduser()
         if not filename.exists():
             return False
-        yaml_settings = __load_yaml(DEFAULT_CONFIG_PATH)
+        yaml_settings = _load_yaml(filename)
         for setting in yaml_settings:
             if error_on_new_attributes and (setting not in self.__dict__):
                 raise ValueError(f'Trying to set unknown attribute {setting}')
-            self.__dict__['setting'] = yaml_settings['setting']
+            self.__dict__[setting] = yaml_settings[setting]
         return True
 
     def load_default_config(self):

--- a/run_notebooks/main.py
+++ b/run_notebooks/main.py
@@ -5,56 +5,47 @@ from .config import Config
 from .run_all_notebooks import process_file_or_directory
 from .setup_log import setup_logger
 
-# This SO answer gives a nice demonstration of how to subclass
-# click.Command to allow for loading from a yaml file
-# https://stackoverflow.com/questions/46358797/python-click-supply-arguments-and-options-from-a-configuration-file
+
+# Useful technique as there is only one command in this application
+# More sophisticated approaches are
+# 1. Setting a custom command class
+#    https://stackoverflow.com/questions/46358797/python-click-supply-arguments-and-options-from-a-configuration-file
+# 2. Creating a new context object to pass along
+#    https://www.brianthicks.com/post/2014/11/03/build-modular-command-line-tools-with-click/
+#
+class Parameters():
+    "Simplified class for resolving config files and pass parameters."
+    def __init__(self, context, config_file=None):
+        # Load config first, so it can be overwritten by context
+        config = Config()
+        config.load_default_config()
+        if config_file:
+            config.load_config_from_file(config_file)
+        self.__dict__ = {key: value for key, value in config.__dict__.items()}
+        for key, value in context.params.items():
+            if value is not None:
+                self.__dict__[key] = value
 
 
-def CommandWithConfigFile(config_file_param_name):
-    class CustomCommandClass(click.Command):
-        def invoke(self, context):
-            file_config = Config()
-            # specified file takes precedence over default, so load
-            # it later
-            file_config.load_default_config()
-            file_config.load_config_from_file(config_file_param_name)
-
-            param_map = {
-                'summary': 'log_summary',
-                'detail': 'log_detail',
-                'summary_file': 'log_summary_name',
-                'detail_file': 'log_summary_name'
-            }
-            # only supply values not given on command line
-            for param, value in context.params.items():
-                config_key = param_map.get(param, param)
-                if (value is None) and (config_key in file_config.__dict__):
-                    context.params[param] = file_config.__dict__[config_key]
-
-            return super().invoke(context)
-
-    return CustomCommandClass
-
-
-@click.command(cls=CommandWithConfigFile('config-file'))
+@click.command()
 @click.argument('notebooks', nargs=-1)
 @click.option('-t', '--timeout', type=int,
               help="Number of seconds before timing out a notebook run")
 @click.option('-c', '--config-file', type=click.Path(),
               help="Config file to load settings from")
-@click.option('-k', '--kernel_name',
+@click.option('-k', '--kernel-name',
               help="Name of the kernel to use "
                    "'jupyter kernelspec list' gets a list")
-@click.option('--summary/--no-summary', default=True,
+@click.option('--summary/--no-summary', default=None,
               help="Determines if summary log is written")
-@click.option('--detail/--no-detail', default=True,
+@click.option('--detail/--no-detail', default=None,
               help="Determines if detailed log is written")
 @click.option('--summary-file', type=click.Path(),
               help="Location of the file for summary of results")
 @click.option('--detail-file', type=click.Path(),
               help="Location of the file for detailed list of errors")
 @click.pass_context
-def pythonrunner(context, *args, **kwargs):
+def pythonrunner(context, config_file, *args, **kwargs):
     """Processes NOTEBOOKS and logs errors.
 
     Running these notebooks does not save the notebook,
@@ -68,8 +59,7 @@ def pythonrunner(context, *args, **kwargs):
     By default, output is logged in the hidden files
     .error_log_summary and .error_log_detail
     """
-    params = type('', (object,), context.params)()
-
+    params = Parameters(context, config_file)
     if params.summary and params.summary_file:
         setup_logger(params.summary_file, level=logging.INFO)
     if params.detail and params.detail_file:

--- a/run_notebooks/main.py
+++ b/run_notebooks/main.py
@@ -57,7 +57,10 @@ def pythonrunner(context, config_file, *args, **kwargs):
     when searching directories.
 
     By default, output is logged in the hidden files
-    .error_log_summary and .error_log_detail
+    .error_log_summary and .error_log_detail.
+
+    More detail and usage patterns can be found on the
+    project page https://github.com/kiwidamien/runpython/
     """
     params = Parameters(context, config_file)
     if params.summary and params.summary_file:

--- a/run_notebooks/setup_log.py
+++ b/run_notebooks/setup_log.py
@@ -19,6 +19,3 @@ def setup_logger(filename, level=logging.DEBUG):
 stream_handler = logging.StreamHandler()
 stream_handler.setLevel(logging.INFO)
 logger.addHandler(stream_handler)
-
-setup_logger('.error_log_detail')
-setup_logger('.error_log_summary', logging.INFO)


### PR DESCRIPTION
- Actually makes config files work (yay!)
- Simplifies the way the context is processed (only one command)
- Retains references to more advanced methods in comments
- Gives example of config file